### PR TITLE
Add source for correct answers

### DIFF
--- a/internal/models/question.go
+++ b/internal/models/question.go
@@ -28,6 +28,7 @@ type Question struct {
 	UserAnswer     int          `yaml:"userAnswer,omitempty"`
 	Answers        Answers      `yaml:"answers,omitempty" gorm:"type:VARCHAR(255)"`
 	AllowedSeconds int          `yaml:"allowedSeconds,omitempty"`
+	Source         string       `yaml:"source,omitempty"`
 	StartedAt      time.Time
 }
 

--- a/views/quizzes/result.html
+++ b/views/quizzes/result.html
@@ -28,7 +28,12 @@
               <!-- Correct Answer -->
               <div class="mb-2">
                 [[ $idx := sub $q.RightAnswer 1 ]]
-                <p class="text-xl">[[ index $q.Answers $idx ]]</p>
+                <p class="text-xl">
+                  [[ index $q.Answers $idx ]]
+                  [[ if not (eq $q.Source "") ]]
+                  <span class="text-sm"><a href="[[ $q.Source ]]" target="_blank" class="text-blue-500 underline">Read the docs</a></span>
+                  [[ end ]]
+                </p>
               </div>
 
               [[ if not (eq $q.RightAnswer $q.UserAnswer) ]]

--- a/views/quizzes/result.html
+++ b/views/quizzes/result.html
@@ -31,7 +31,7 @@
                 <p class="text-xl">
                   [[ index $q.Answers $idx ]]
                   [[ if not (eq $q.Source "") ]]
-                  <span class="text-sm"><a href="[[ $q.Source ]]" target="_blank" class="text-blue-500 underline">Read the docs</a></span>
+                  <span class="text-sm"><a href="[[ $q.Source ]]" target="_blank" class="text-blue-500 underline">Learn more</a></span>
                   [[ end ]]
                 </p>
               </div>


### PR DESCRIPTION
This way, it is easy for users to learn more about why they had a certain answer wrong or simply to dig into a topic if they find it interesting.

Adding to a question:

```
questions:
  - text: What variants of Kairos exist today?
    difficulty: 1
    type: single-choice
    rightAnswer: 4
    source: https://kairos.io/docs/architecture/immutable/
    answers:
      - Only Core which is a basic Linux system and you have to install everything else
      - Only Standard which includes K3s, EdgeVPN, and other tools
      - Only Ultra which is a gaming variant
      - Core and Standard are available for Linux only workload and Kubernetes workloads accordingly
```

How it looks. As you will notice from the image, if the source was not set, it will not be displayed.

<img width="1230" alt="Screenshot 2024-12-19 at 15 19 55" src="https://github.com/user-attachments/assets/f06ecb62-76af-4105-9562-cb7298dbfefb" />

